### PR TITLE
Adding i18n/localization and static config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,18 @@ SilverStripe\Forms\DateField:
 
 Out of the box, the module will automatically add a [flatpickr][flatpickr] to
 all `DateField`, `DatetimeField` and `TimeField` instances. Each field will
-be configured automatically with default settings for each use case.
+be configured automatically with default settings for each use case. A flatpickr 
+language file will be loaded and used (if available) based on the current i18n locale.
 
 If you need to apply additional options supported by [flatpickr][flatpickr], you
-can do so by using the `setCalendarConfig()` method:
+can do so by using YAML config (static), or the `setCalendarConfig()` method (instance):
+
+```yml
+SilverWare\Calendar\Extensions\FormFieldExtension:
+  flatpickr_base_config:
+    time_24hr: true
+    altFormat: "l j F Y \\o\\m H:i"
+```
 
 ```php
 use SilverStripe\Forms\DateField;

--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -18,6 +18,7 @@
 namespace SilverWare\Calendar\Extensions;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\i18n\i18n;
 use SilverStripe\View\Requirements;
 
 /**
@@ -41,6 +42,19 @@ class ControllerExtension extends Extension
         if ($this->owner->getCalendarHighlightColor()) {
             Requirements::customCSS($this->getCustomCSS());
         }
+    }
+    
+    /**
+     * Event handler method triggered after the extended controller has initialised.
+     *
+     * @return void
+     */
+    public function onAfterInit()
+    {
+        // (try &) load locale file + set default locale for flatpickr to current users' i18n locale
+        $userLangIso = i18n::getData()->langFromLocale(i18n::get_locale());
+        Requirements::javascript("//npmcdn.com/flatpickr/dist/l10n/$userLangIso.js");
+        Requirements::customScript("flatpickr.localize(flatpickr.l10ns.$userLangIso);");
     }
     
     /**

--- a/src/Extensions/ControllerExtension.php
+++ b/src/Extensions/ControllerExtension.php
@@ -54,7 +54,7 @@ class ControllerExtension extends Extension
         // (try &) load locale file + set default locale for flatpickr to current users' i18n locale
         $userLangIso = i18n::getData()->langFromLocale(i18n::get_locale());
         Requirements::javascript("//npmcdn.com/flatpickr/dist/l10n/$userLangIso.js");
-        Requirements::customScript("flatpickr.localize(flatpickr.l10ns.$userLangIso);");
+        Requirements::customScript("flatpickr.localize(flatpickr.l10ns.$userLangIso);", "FlatpickrLocalization");
     }
     
     /**

--- a/src/Extensions/FormFieldExtension.php
+++ b/src/Extensions/FormFieldExtension.php
@@ -17,6 +17,7 @@
 
 namespace SilverWare\Calendar\Extensions;
 
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FormField;
@@ -32,6 +33,13 @@ use SilverStripe\Forms\FormField;
  */
 class FormFieldExtension extends Extension
 {
+    use Configurable;
+
+    /**
+     * (Standard/default) config object for static flatpickr config (merged with instance $calendarConfig)
+     */
+    private static $flatpickr_base_config = [];
+    
     /**
      * Holds the calendar picker config for the extended object.
      *
@@ -74,11 +82,16 @@ class FormFieldExtension extends Extension
      */
     public function getCalendarConfig($name = null)
     {
+        $mergedConfig = array_merge(
+            $this->config()->get('flatpickr_base_config'),
+            $this->calendarConfig
+        );
+
         if (!is_null($name)) {
-            return isset($this->calendarConfig[$name]) ? $this->calendarConfig[$name] : null;
+            return isset($mergedConfig[$name]) ? $mergedConfig[$name] : null;
         }
         
-        return $this->calendarConfig;
+        return $mergedConfig;
     }
     
     /**


### PR DESCRIPTION
- adds & sets language JS file Requirement based on i18n current locale (from CDN, exernal dependency)
- first day of week etc is also contained in language/locale files, so should be correct
- adds the standard SS Yaml based config system to allow setting default configuration options for flatpickr

@TODO: 
- could be extended to use contentLocale in front-end contexts to auto-include front-end i18n
- could be refactored to include & expose the locale/language files so they could be loaded locally instead of via CDN

Fixes #2